### PR TITLE
Fix where we put the `extra` metadata

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -54,10 +54,12 @@ class MetaData(CondaMetaData):
         if not rendered_recipe:
             self.meta = self.parse_recipe()
             self.meta["about"] = self.meta.get("about", {})
+            self.meta["extra"] = self.meta.get("extra", {})
         else:
             self.meta = rendered_recipe
             self._rendered = True
             self.meta["about"] = self.meta["recipe"].get("about", {})
+            self.meta["extra"] = self.meta["recipe"].get("extra", {})
 
         self.final = True
         self.undefined_jinja_vars = []


### PR DESCRIPTION
Conda-smithy expects the maintainers under `meta.meta["extra"]["recipe-maintainers"]`.
However, we had them under `meta.meta["recipe"]["extra"]["recipe-maintainers"].

I am not sure, but maybe we should just move the whole recipe under the `meta` key?