### PR TITLE
Fix wrong target/build platform during rendering

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -118,7 +118,8 @@ class MetaData(CondaMetaData):
         return version
 
     def render_recipes(self, variants) -> List[Dict]:
-        platform_and_arch = f"{self.config.platform}-{self.config.arch}"
+        build_platform_and_arch = f"{self.config.platform}-{self.config.arch}"
+        target_platform_and_arch = f"{self.config.host_platform}-{self.config.host_arch}"
         yaml = _yaml_object()
         try:
             with tempfile.NamedTemporaryFile(mode="w+") as outfile:
@@ -136,9 +137,9 @@ class MetaData(CondaMetaData):
                         "--recipe",
                         self.path,
                         "--target-platform",
-                        platform_and_arch,
+                        target_platform_and_arch,
                         "--build-platform",
-                        platform_and_arch,
+                        build_platform_and_arch,
                     ]
 
                     if variants:

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -121,15 +121,6 @@ class MetaData(CondaMetaData):
         build_platform_and_arch = f"{self.config.platform}-{self.config.arch}"
         target_platform_and_arch = f"{self.config.host_platform}-{self.config.host_arch}"
 
-        print("***************************************************")
-
-        print(f"build_platform_and_arch: {build_platform_and_arch}")
-        print(f"target_platform_and_arch: {target_platform_and_arch}")
-        print(f"variants: {variants}")
-        print(f"config: {self.config}")
-
-        print("***************************************************")
-
         yaml = _yaml_object()
         try:
             with tempfile.NamedTemporaryFile(mode="w+") as outfile:

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -120,6 +120,16 @@ class MetaData(CondaMetaData):
     def render_recipes(self, variants) -> List[Dict]:
         build_platform_and_arch = f"{self.config.platform}-{self.config.arch}"
         target_platform_and_arch = f"{self.config.host_platform}-{self.config.host_arch}"
+
+        print("***************************************************")
+
+        print(f"build_platform_and_arch: {build_platform_and_arch}")
+        print(f"target_platform_and_arch: {target_platform_and_arch}")
+        print(f"variants: {variants}")
+        print(f"config: {self.config}")
+
+        print("***************************************************")
+
         yaml = _yaml_object()
         try:
             with tempfile.NamedTemporaryFile(mode="w+") as outfile:


### PR DESCRIPTION
The issue only appeared during cross compilation when target was different from the build platform.

I encountered the issue when converting a feedstock to rattler at https://github.com/conda-forge/xformers-feedstock/pull/33

Sister PR: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/360