### PR TITLE
fix: fallback target platform

### DIFF
--- a/src/rattler_build_conda_compat/jinja/jinja.py
+++ b/src/rattler_build_conda_compat/jinja/jinja.py
@@ -43,7 +43,7 @@ def jinja_env(variant_config: Mapping[str, str] | None = None) -> SandboxedEnvir
         variant_config = {"target_platform": "linux-64", "build_platform": "linux-64", "mpi": "mpi"}
 
     extra_vars = {}
-    target_platform = variant_config["target_platform"]
+    target_platform = variant_config.get("target_platform", "linux-64")
     if target_platform != "noarch":
         # set `linux` / `win`
         platform, arch = target_platform.split("-")


### PR DESCRIPTION
version updates for `noarch` recipes are currently failing because they don't include a target_platform key. 

With this change we just fall back to `linux-64`.
