### PR TITLE
Fix variant value type mismatch with newer rattler-build

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -308,7 +308,9 @@ def render(
                 ) in used_variant.items():
                     if used_variant_key in pkg_variant:
                         if (
-                            pkg_variant[used_variant_key] != used_variant_value
+                            # convert both values to str(), since conda-smithy passes strings
+                            # in variants, but package_variants contain actual types
+                            str(pkg_variant[used_variant_key]) != str(used_variant_value)
                             and pkg_variant in package_variants
                         ):
                             package_variants.remove(pkg_variant)

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -311,9 +311,9 @@ def render(
                             # convert both values to str(), since conda-smithy passes strings
                             # in variants, but package_variants contain actual types
                             str(pkg_variant[used_variant_key]) != str(used_variant_value)
-                            and pkg_variant in package_variants
                         ):
                             package_variants.remove(pkg_variant)
+                            break
 
             m.config.variant = package_variants[0]
 

--- a/tests/__snapshots__/test_rattler_loader.ambr
+++ b/tests/__snapshots__/test_rattler_loader.ambr
@@ -49,6 +49,10 @@
 # ---
 # name: test_load_variants
   dict({
+    'c_compiler_version': list([
+      13,
+      14,
+    ]),
     'liboost': list([
       '0.10.01.001',
       '0.10',

--- a/tests/__snapshots__/test_rattler_render.ambr
+++ b/tests/__snapshots__/test_rattler_render.ambr
@@ -39,10 +39,22 @@
 # name: test_render_recipe
   list([
     dict({
+      'c_compiler_version': '13',
       'python': '3.8.* *_cpython',
       'target_platform': 'linux-64',
     }),
     dict({
+      'c_compiler_version': '13',
+      'python': '3.9.* *_cpython',
+      'target_platform': 'linux-64',
+    }),
+    dict({
+      'c_compiler_version': '14',
+      'python': '3.8.* *_cpython',
+      'target_platform': 'linux-64',
+    }),
+    dict({
+      'c_compiler_version': '14',
       'python': '3.9.* *_cpython',
       'target_platform': 'linux-64',
     }),

--- a/tests/data/py_recipe.yaml
+++ b/tests/data/py_recipe.yaml
@@ -3,6 +3,7 @@ package:
     version: 1.0.0
 requirements:
     build:
+      - "${{ compiler('c') }}"
       - if: win
         then:
           - ruby

--- a/tests/data/variants.yaml
+++ b/tests/data/variants.yaml
@@ -20,3 +20,7 @@ liboost:
 ruby:
   - if : unix
     then: 2.5
+
+c_compiler_version:
+  - 13
+  - 14

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -18,7 +18,7 @@ def test_render_recipe(python_recipe: Path, unix_namespace: dict[str, Any], snap
 
     all_used_variants = [meta[0].get_used_variant() for meta in rendered]
 
-    assert len(all_used_variants) == 2
+    assert len(all_used_variants) == 4
 
     assert snapshot == all_used_variants
 


### PR DESCRIPTION
Fix the variant value comparison to match strings, in order to handle argument mismatch between `used_variant` and `package_variants`. With newer rattler-build versions, the former has actual types, while the latter has strings, so e.g. `13 != "13"` and no variant is matched, resulting in an `IndexError`.  Add a dummy `c_compiler_version` use to the test recipe to reproduce it.