### PR TITLE
consistently set `encoding=utf-8` for opening files

### DIFF
--- a/src/rattler_build_conda_compat/lint.py
+++ b/src/rattler_build_conda_compat/lint.py
@@ -306,7 +306,7 @@ def lint_variable_reference_should_have_space(recipe_dir, recipe_file):
     if recipe_dir is not None and os.path.exists(recipe_file):
         bad_vars = []
         bad_lines = []
-        with open(recipe_file, "r") as fh:
+        with open(recipe_file, "r", encoding="utf-8") as fh:
             for i, line in enumerate(fh.readlines()):
                 for m in JINJA_VAR_PAT.finditer(line):
                     if m.group(1) is not None:

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -69,7 +69,7 @@ class MetaData(CondaMetaData):
     def parse_recipe(self) -> dict[str, Any]:
         recipe_path: Path = Path(self.path) / self._meta_name
 
-        yaml_content = load_yaml(recipe_path.read_text())
+        yaml_content = load_yaml(recipe_path.read_text(encoding="utf-8"))
 
         return render_recipe_with_context(yaml_content)
 
@@ -123,8 +123,8 @@ class MetaData(CondaMetaData):
 
         yaml = _yaml_object()
         try:
-            with tempfile.NamedTemporaryFile(mode="w+") as outfile:
-                with tempfile.NamedTemporaryFile(mode="w") as variants_file:
+            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as outfile:
+                with tempfile.NamedTemporaryFile(mode="w", encoding="utf-8") as variants_file:
                     # dump variants in our variants that will be used to generate recipe
                     if variants:
                         yaml.dump(variants, variants_file)


### PR DESCRIPTION
Companion to https://github.com/conda-forge/conda-smithy/pull/2244; necessary to rerender rattler recipes on windows.