### PR TITLE
don't include subpackages in used variant

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -162,8 +162,11 @@ class MetaData(CondaMetaData):
             # return empty
             return set()
 
+        # don't include subpackages in used_vars
         used_vars = [
-            var.replace("-", "_") for var in self.meta["build_configuration"]["variant"].keys()
+            var.replace("-", "_")
+            for var in self.meta["build_configuration"]["variant"].keys()
+            if var not in self.meta["build_configuration"]["subpackages"]
         ]
 
         # in conda-build target-platform is not returned as part of yaml vars
@@ -187,6 +190,10 @@ class MetaData(CondaMetaData):
         used_variant_key_normalized = {}
 
         for key, value in used_variant.items():
+            if key in self.meta["build_configuration"]["subpackages"]:
+                # don't include subpackage names in used_variant
+                continue
+
             normalized_key = key.replace("-", "_")
             used_variant_key_normalized[normalized_key] = value
 

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -89,3 +89,23 @@ def test_metadata_when_rendering_multiple_output(
 
     assert rendered[0][0].name() == "libmamba"
     assert rendered[0][0].version() == "1.5.8"
+
+
+def test_used_variant(feedstock_dir_with_recipe: Path, multiple_outputs: Path) -> None:
+    recipe_path = feedstock_dir_with_recipe / "recipe" / "recipe.yaml"
+    (recipe_path).write_text(multiple_outputs.read_text(), encoding="utf8")
+
+    # e.g. conda-forge, variant file may include variants
+    # on outputs from the given package
+    variants = {
+        "libmamba": ["1", "2"],
+        "python": ["3.12", "3.13"],
+    }
+    rendered = render(str(recipe_path), variants=variants, platform="linux", arch="64")
+    # 3 outputs, 2 of which use python
+    assert len(rendered) == 5
+    meta = rendered[-1][0]
+    assert "libmamba" not in meta.get_used_vars()
+    assert "libmamba" not in meta.get_used_variant()
+    assert "python" in meta.get_used_variant()
+    assert "python" in meta.get_used_variant()


### PR DESCRIPTION
results in excluding all variants if the variant file includes pins on subpackage outputs (common in conda-forge) leading to IndexError because `package_variants` is empty:

```
>               m.config.variant = package_variants[0]
E               IndexError: list index out of range
```

For example, [suitesparse-feedstock](https://github.com/conda-forge/suitesparse-feedstock/pull/104) recently started failing to rerender because of this, since the `used_variant` for most outputs had `libsuitesparseconfig: 7.9.0 ss790_h0795de7`, while all `package_variants` had `libsuitesparseconfig: 7`, leading to excluding all `package_variants`


I don't know if this is a more general issue or indeed a bug in rattler-build that internal state is being included in the 'variant' input to package metadata, but at least this fix allows suitesparse-feedstock (and likely many other multi-output conda-forge feedstocks) to render.