### PR TITLE
handle run_exports, ignore_run_exports dict format in load_all_requirements

### DIFF
--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -122,6 +122,11 @@ def load_all_requirements(content: dict[str, Any]) -> dict[str, Any]:
 
     for section in requirements_section:
         section_reqs = requirements_section[section]
+
+        if section == "run_exports" and isinstance(section_reqs, dict):
+            # flatten 'weak:', 'strong:' to a single list of requirements
+            section_reqs = list(itertools.chain(*section_reqs.values()))
+
         if not section_reqs:
             continue
 

--- a/src/rattler_build_conda_compat/loader.py
+++ b/src/rattler_build_conda_compat/loader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import io
 import itertools
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from rattler_build_conda_compat.conditional_list import visit_conditional_list
 from rattler_build_conda_compat.yaml import _yaml_object
@@ -127,10 +127,12 @@ def load_all_requirements(content: dict[str, Any]) -> dict[str, Any]:
             section_reqs = {  # noqa: PLW2901
                 "weak": section_reqs
             }
+        filtered_reqs: list | dict[str, list]
         if isinstance(section_reqs, dict):
             filtered_reqs = {}
             # run_exports, ignore_run_exports are dicts of lists
             for key, sub_reqs in section_reqs.items():
+                key = cast(str, key)
                 filtered_sub_reqs = list(visit_conditional_list(sub_reqs))
                 if filtered_sub_reqs:
                     filtered_reqs[key] = filtered_sub_reqs

--- a/tests/data/recipe_requirements.yaml
+++ b/tests/data/recipe_requirements.yaml
@@ -16,3 +16,6 @@ requirements:
       - weakreq
     strong:
       - strongreq
+  ignore_run_exports:
+    from_package:
+      - python

--- a/tests/data/recipe_requirements.yaml
+++ b/tests/data/recipe_requirements.yaml
@@ -6,3 +6,13 @@ requirements:
         - ${{ cdt('xorg-x11-proto-devel') }}
   host:
     - python
+  run_exports:
+    weak:
+      - if: osx
+        then:
+          - weak-then
+        else:
+          - weak-else
+      - weakreq
+    strong:
+      - strongreq

--- a/tests/test_rattler_loader.py
+++ b/tests/test_rattler_loader.py
@@ -26,12 +26,11 @@ def test_load_all_requirements() -> None:
 
     content = load_all_requirements(recipe_content)
     print(content)
-    assert sorted(content["run_exports"]) == [
-        "strongreq",
-        "weak-else",
-        "weak-then",
-        "weakreq",
-    ]
+    assert content["run_exports"] == {
+        "weak": ["weak-then", "weak-else", "weakreq"],
+        "strong": ["strongreq"],
+    }
+    assert content["ignore_run_exports"] == {"from_package": ["python"]}
 
 
 def test_load_recipe_with_missing_selectors(snapshot) -> None:

--- a/tests/test_rattler_loader.py
+++ b/tests/test_rattler_loader.py
@@ -26,6 +26,12 @@ def test_load_all_requirements() -> None:
 
     content = load_all_requirements(recipe_content)
     print(content)
+    assert sorted(content["run_exports"]) == [
+        "strongreq",
+        "weak-else",
+        "weak-then",
+        "weakreq",
+    ]
 
 
 def test_load_recipe_with_missing_selectors(snapshot) -> None:


### PR DESCRIPTION
closes #73  by ensuring `run_exports` and `ignore_run_exports` preserve their dict structure.

This also results in consistent output for the equivalent yaml:

```
run_exports:
  - foo
```

and 

```
run_exports:
  weak:
    - foo
```

both of which return the latter dict.