### PR TITLE
make sure unused variants are scalars

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -393,7 +393,13 @@ def _reduce_variants(m: MetaData, variants: list[dict] | None) -> tuple[dict, di
     unused_variants = {}
     for key in all_variants:
         if key not in reduced_variants:
-            unused_variants[key] = all_variants[key]
+            # unused, but get first scalar to make sure it's the right shape
+            # in case it's used outside (e.g. in conda-smithy)
+            unused_value = all_variants[key]
+            if isinstance(unused_value, list) and unused_value:
+                unused_value = unused_value[0]
+
+            unused_variants[key] = unused_value
     return reduced_variants, unused_variants
 
 

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -99,6 +99,7 @@ def test_used_variant(feedstock_dir_with_recipe: Path, multiple_outputs: Path) -
     # on outputs from the given package
     variants = {
         "libmamba": ["1", "2"],
+        "unused": "scalar",
         "python": ["3.12", "3.13"],
     }
     rendered = render(str(recipe_path), variants=variants, platform="linux", arch="64")
@@ -109,3 +110,11 @@ def test_used_variant(feedstock_dir_with_recipe: Path, multiple_outputs: Path) -
     assert "libmamba" not in meta.get_used_variant()
     assert "python" in meta.get_used_variant()
     assert "python" in meta.get_used_variant()
+
+    # make sure unused variants are still in the variant dicts,
+    # but reduced to first scalar
+    assert "libmamba" in meta.config.variant
+    for variant in meta.config.variants:
+        assert variant["libmamba"] == "1"
+
+    assert "unused" in meta.config.variant


### PR DESCRIPTION
reduced to first scalar, as it would have done before in deduplicating

not original lists, to preserve expected structure of variant dicts

fixes the rerender problem in https://github.com/conda-forge/marimo-feedstock/pull/210#issuecomment-2774112182

I'm not sure why this situation doesn't come up in any conda-smithy tests