### PR TITLE
override meta.build_id so meta.dist() works

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -97,6 +97,19 @@ class MetaData(CondaMetaData):
         check_bad_chrs(name, "package/name")
         return name
 
+    def build_id(self) -> str:
+        """
+        Overrides the conda_build.metadata.MetaData.build_ method.
+
+        This is used to compute metadata.dist()
+
+        When rendered, gets the computed value from recipe/build/string.
+        When unrendered, gets build/string if defined, else the placeholder 'unrendered_0'
+        """
+        if self._rendered:
+            return self.meta["recipe"]["build"]["string"]
+        return self.meta.get("build", {}).get("string", "unrendered_0")
+
     def version(self) -> str:
         """
         Overrides the conda_build.metadata.MetaData.version method.

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -54,6 +54,7 @@ def test_metadata_for_single_output(feedstock_dir_with_recipe: Path, rich_recipe
 
     assert rattler_metadata.name() == "rich"
     assert rattler_metadata.version() == "13.4.2"
+    assert rattler_metadata.dist() == "rich-13.4.2-unrendered_0"
 
 
 def test_metadata_for_multiple_output(feedstock_dir_with_recipe: Path, mamba_recipe: Path) -> None:
@@ -74,9 +75,15 @@ def test_metadata_when_rendering_single_output(
     (recipe_path).write_text(rich_recipe.read_text(), encoding="utf8")
 
     rendered = render(str(recipe_path), platform="linux", arch="64")
-
-    assert rendered[0][0].name() == "rich"
-    assert rendered[0][0].version() == "13.4.2"
+    meta = rendered[0][0]
+    assert meta.name() == "rich"
+    assert meta.version() == "13.4.2"
+    dist = meta.dist()
+    dist_name, dist_version, build_id = dist.split("-")
+    assert dist_name == meta.name()
+    assert dist_version == meta.version()
+    assert build_id.startswith("pyh")
+    assert build_id.endswith("_0")
 
 
 def test_metadata_when_rendering_multiple_output(


### PR DESCRIPTION
conda-smithy has [started to use meta.dist()](https://github.com/conda-forge/conda-smithy/pull/2300/files#diff-dc66a1980eec62725cfb8b6faea5b3c90dc7d1009d1229f5f55eecfb267a6677R1200), which [fails](https://github.com/conda-forge/conda-forge-webservices/actions/runs/14569433726/job/40863863605#step:5:4700) for many v1 recipes (I think any with a templated build string) with:

```
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/conda_smithy/configure_feedstock.py", line 1200, in <lambda>
    metas = sorted(metas, key=lambda x: x.dist())
                                        ^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/conda_build/metadata.py", line 1822, in dist
    return f"{self.name()}-{self.version()}-{self.build_id()}"
                                             ^^^^^^^^^^^^^^^
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/conda_build/metadata.py", line 1801, in build_id
    check_bad_chrs(manual_build_string, "build/string")
  File "/opt/conda/envs/cf-feedstock-ops/lib/python3.11/site-packages/conda_build/metadata.py", line 834, in check_bad_chrs
    raise CondaBuildUserError(
conda_build.exceptions.CondaBuildUserError: Bad character(s) ( $'|) in build/string: cuda${{ cuda_compiler_version | default('None') }}_${{ scalar | default('real') }}_h${{ hash }}_3.
```