### PR TITLE
make sure to return booleans as strings from render

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -10933,8 +10933,8 @@ packages:
   timestamp: 1755690781201
 - pypi: ./
   name: rattler-build-conda-compat
-  version: 1.4.4
-  sha256: ed9ac1c8c0bbc00bb8d8034fc94c57ae48677717db1e245325934890cb6d275f
+  version: 1.4.5
+  sha256: c56d9b5889c4e5b80369e28dbe3aff400d2a87a5e10ff39baa2b8681ec3dca21
   requires_dist:
   - typing-extensions>=4.12,<5
   - jinja2>=3.0.2,<4

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rattler-build-conda-compat"
-version = "1.4.4"
+version = "1.4.5"
 description = "A package for exposing rattler-build API for conda-smithy"
 authors = ["nichmor <nmorkotilo@gmail.com>"]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "rattler-build-conda-compat"
 description = "A package for exposing rattler-build API for conda-smithy"
-version = "1.4.4"
+version = "1.4.5"
 readme = "README.md"
 authors = [{ name = "Nichita Morcotilo", email = "nichita@prefix.dev" }]
 license = { file = "LICENSE.txt" }

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -209,6 +209,13 @@ class MetaData(CondaMetaData):
                 continue
 
             normalized_key = key.replace("-", "_")
+            # conda-build variants are always strings
+            # coerce bool back to str
+            if value is True:
+                value = "true"
+            elif value is False:
+                value = "false"
+
             used_variant_key_normalized[normalized_key] = value
 
         # in conda-build target-platform is not returned as part of yaml vars

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,6 +73,11 @@ def mamba_recipe() -> Path:
 
 
 @pytest.fixture()
+def py_abi3_recipe() -> Path:
+    return Path("tests/data/py_abi3.yaml")
+
+
+@pytest.fixture()
 def rich_recipe() -> Path:
     return Path("tests/data/rich_recipe.yaml")
 

--- a/tests/data/py_abi3.yaml
+++ b/tests/data/py_abi3.yaml
@@ -1,0 +1,18 @@
+package:
+    name: py-test
+    version: 1.0.0
+build:
+    python:
+        version_independent: true
+requirements:
+    build:
+      - if: win
+        then:
+          - ${{ compiler('c') }}
+    host:
+        - python
+        - if: is_abi3 and not is_python_min
+          then:
+            - python-abi3
+    run:
+        - python

--- a/tests/data/py_abi3.yaml
+++ b/tests/data/py_abi3.yaml
@@ -5,13 +5,9 @@ build:
     python:
         version_independent: true
 requirements:
-    build:
-      - if: win
-        then:
-          - ${{ compiler('c') }}
     host:
         - python
-        - if: is_abi3 and not is_python_min
+        - if: is_abi3
           then:
             - python-abi3
     run:

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -142,7 +142,7 @@ def test_bool_roundtrip(feedstock_dir_with_recipe: Path, py_abi3_recipe: Path) -
         ],
     }
     rendered = render(str(recipe_path), variants=variants, platform="linux", arch="64")
-    # 3 outputs, 2 of which use python
+    # 2 outputs, one is_abi3=true, one is_abi3=false
     assert len(rendered) == 2
     meta_abi3, meta_noabi3 = rendered[0][0], rendered[1][0]
     # make sure result is still conda-build-style string


### PR DESCRIPTION
#85 only dealt with one direction of the conversion. We also have to convert True back to 'true' in `get_used_variant` in order to compare with input variants.

More thorough test added, too, explicitly exercising `is_abi3` as a bool.