### PR TITLE
fix: ensure yaml changes are not global

### DIFF
--- a/src/rattler_build_conda_compat/yaml.py
+++ b/src/rattler_build_conda_compat/yaml.py
@@ -26,11 +26,11 @@ def _yaml_represent_str(yaml_representer: SafeRepresenter, data: str) -> ScalarN
 def _yaml_object() -> YAML:
     yaml = YAML(typ="rt")
 
-    class _CustomConstructor(yaml.Constructor)
+    class _CustomConstructor(yaml.Constructor):
         yaml_constructors = {}
         yaml_multi_constructors = {}
 
-    class _CustomRepresenter(yaml.Representer)
+    class _CustomRepresenter(yaml.Representer):
         yaml_representers = {}
         yaml_multi_representers = {}
 

--- a/src/rattler_build_conda_compat/yaml.py
+++ b/src/rattler_build_conda_compat/yaml.py
@@ -27,11 +27,17 @@ def _yaml_object() -> YAML:
     yaml = YAML(typ="rt")
 
     class _CustomConstructor(yaml.Constructor)
-        pass
+        yaml_constructors = {}
+        yaml_multi_constructors = {}
+
+    class _CustomRepresenter(yaml.Representer)
+        yaml_representers = {}
+        yaml_multi_representers = {}
 
     yaml.Constructor = _CustomConstructor
     yaml.Constructor.add_constructor("tag:yaml.org,2002:float", float_as_string_constructor)
-    yaml.representer.add_representer(str, _yaml_represent_str)
+    yaml.Representer = _CustomRepresenter
+    yaml.Representer.add_representer(str, _yaml_represent_str)
     yaml.allow_duplicate_keys = False
     yaml.preserve_quotes = True
     yaml.width = 320

--- a/src/rattler_build_conda_compat/yaml.py
+++ b/src/rattler_build_conda_compat/yaml.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from typing import Any
+from typing import Any, ClassVar
 
 from ruamel.yaml import YAML
 from ruamel.yaml.representer import SafeRepresenter, ScalarNode
@@ -27,12 +27,18 @@ def _yaml_object() -> YAML:
     yaml = YAML(typ="rt")
 
     class _CustomConstructor(yaml.Constructor):
-        yaml_constructors = {}
-        yaml_multi_constructors = {}
+        yaml_constructors: ClassVar = {}
+        yaml_multi_constructors: ClassVar = {}
 
     class _CustomRepresenter(yaml.Representer):
-        yaml_representers = {}
-        yaml_multi_representers = {}
+        yaml_representers: ClassVar = {}
+        yaml_multi_representers: ClassVar = {}
+
+    _CustomConstructor.yaml_constructors.update(yaml.Constructor.yaml_constructors)
+    _CustomConstructor.yaml_multi_constructors.update(yaml.Constructor.yaml_multi_constructors)
+
+    _CustomRepresenter.yaml_representers.update(yaml.Representer.yaml_representers)
+    _CustomRepresenter.yaml_multi_representers.update(yaml.Representer.yaml_multi_representers)
 
     yaml.Constructor = _CustomConstructor
     yaml.Constructor.add_constructor("tag:yaml.org,2002:float", float_as_string_constructor)

--- a/src/rattler_build_conda_compat/yaml.py
+++ b/src/rattler_build_conda_compat/yaml.py
@@ -25,6 +25,11 @@ def _yaml_represent_str(yaml_representer: SafeRepresenter, data: str) -> ScalarN
 
 def _yaml_object() -> YAML:
     yaml = YAML(typ="rt")
+
+    class _CustomConstructor(yaml.Constructor)
+        pass
+
+    yaml.Constructor = _CustomConstructor
     yaml.Constructor.add_constructor("tag:yaml.org,2002:float", float_as_string_constructor)
     yaml.representer.add_representer(str, _yaml_represent_str)
     yaml.allow_duplicate_keys = False

--- a/src/rattler_build_conda_compat/yaml.py
+++ b/src/rattler_build_conda_compat/yaml.py
@@ -26,11 +26,11 @@ def _yaml_represent_str(yaml_representer: SafeRepresenter, data: str) -> ScalarN
 def _yaml_object() -> YAML:
     yaml = YAML(typ="rt")
 
-    class _CustomConstructor(yaml.Constructor):
+    class _CustomConstructor(yaml.Constructor):  # type: ignore[name-defined]
         yaml_constructors: ClassVar = {}
         yaml_multi_constructors: ClassVar = {}
 
-    class _CustomRepresenter(yaml.Representer):
+    class _CustomRepresenter(yaml.Representer):  # type: ignore[name-defined]
         yaml_representers: ClassVar = {}
         yaml_multi_representers: ClassVar = {}
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,34 @@
+import io
+
+from rattler_build_conda_compat import yaml as rbcc_yaml
+from ruamel.yaml import YAML
+
+
+def test_yaml_dump_no_global_changes() -> None:
+    data = {"value": "true"}
+
+    for kind in ["global", "rbcc", "global", "rbcc"]:
+        if kind == "global":
+            yaml = YAML()
+            sdata = io.StringIO()
+            yaml.dump(data, sdata)
+            assert sdata.getvalue() == "value: 'true'\n"
+        else:
+            yaml = rbcc_yaml._yaml_object()
+            rbcc_sdata = io.StringIO()
+            yaml.dump(data, rbcc_sdata)
+            assert rbcc_sdata.getvalue() == "value: true\n"
+
+
+def test_yaml_load_no_global_changes() -> None:
+    sdata = "value: 0.02\n"
+
+    for kind in ["global", "rbcc", "global", "rbcc"]:
+        if kind == "global":
+            yaml = YAML()
+            data = yaml.load(sdata)
+            assert data == {"value": 0.02}
+        else:
+            yaml = rbcc_yaml._yaml_object()
+            rbcc_data = yaml.load(sdata)
+            assert rbcc_data == {"value": "0.02"}


### PR DESCRIPTION
This PR ensures that the changes made to the YAML parser do not have global side effects.