### PR TITLE
fix: render_all_sources now finds sources in outputs and cache

### DIFF
--- a/src/rattler_build_conda_compat/recipe_sources.py
+++ b/src/rattler_build_conda_compat/recipe_sources.py
@@ -109,6 +109,35 @@ def get_all_url_sources(recipe: MutableMapping[str, Any]) -> Iterator[str]:
     return (get_first_url(source) for source in get_all_sources(recipe) if "url" in source)
 
 
+def _collect_source_sections(
+    recipe: RecipeWithContext,
+    selector: typing.Callable[[str], bool],
+) -> list[Any]:
+    """Collect raw source sections from top-level, cache, and outputs."""
+    sections: list[Any] = []
+
+    top_level = recipe.get("source")
+    if top_level:
+        sections.append(top_level)
+
+    cache = recipe.get("cache")
+    if cache is not None:
+        cache = typing.cast("dict[str, Any]", cache)
+        cache_sources = cache.get("source")
+        if cache_sources:
+            sections.append(cache_sources)
+
+    outputs = recipe.get("outputs")
+    if outputs:
+        for output in visit_conditional_list(outputs, selector):
+            output_dict = typing.cast("dict[str, Any]", output)
+            output_sources = output_dict.get("source")
+            if output_sources:
+                sections.append(output_sources)
+
+    return sections
+
+
 def render_all_sources(  # noqa: C901
     recipe: RecipeWithContext,
     variants: list[dict[str, list[str]]],
@@ -140,14 +169,16 @@ def render_all_sources(  # noqa: C901
             context_variables = load_recipe_context(context, env)
 
             # now evaluate the if / else statements
-            sources = recipe.get("source")
-            if sources:
-                if not isinstance(sources, list):
-                    sources = [sources]
+            # collect source sections from all locations: top-level, cache, and outputs
+            selector = lambda x, combination=env.globals: _eval_selector(x, combination)  # type: ignore[misc]  # noqa: E731
+            all_source_sections = _collect_source_sections(recipe, selector)
+
+            for sources in all_source_sections:
+                source_list = sources if isinstance(sources, list) else [sources]
 
                 for elem in visit_conditional_list(
-                    sources,
-                    lambda x, combination=env.globals: _eval_selector(x, combination),  # type: ignore[misc]
+                    source_list,
+                    selector,
                 ):
                     # we need to explicitly cast here
                     elem_dict = typing.cast("dict[str, Any]", elem)

--- a/tests/__snapshots__/test_recipe_sources.ambr
+++ b/tests/__snapshots__/test_recipe_sources.ambr
@@ -21,6 +21,13 @@
     Source(url=['https://foo.com/win-64/zip.zip', 'https://mirror.com/win-64/zip.zip'], template=['https://foo.com/${{ target_platform }}/zip.zip', 'https://mirror.com/${{ target_platform }}/zip.zip'], context={'name': 'foobar', 'version': '1.2.3'}, sha256='xxx', md5=None),
   })
 # ---
+# name: test_outputs_only_source_render
+  set({
+    Source(url='https://pypi.org/packages/source/d/dirac/dirac-9.0.16.tar.gz', template='https://pypi.org/packages/source/d/dirac/dirac-${{ version }}.tar.gz', context={'version': '9.0.16'}, sha256='548b85b3b0ecf17487f3deba5073763583dd7eb812bf063f409153fc44c7402f', md5=None),
+    Source(url='https://pypi.org/packages/source/d/diraccommon/diraccommon-9.0.16.tar.gz', template='https://pypi.org/packages/source/d/diraccommon/diraccommon-${{ version }}.tar.gz', context={'version': '9.0.16'}, sha256='7ae43c63075770e1314c40f2e7bd7708ae22a45262489e8912b881adf9f1aa2c', md5=None),
+    Source(url='https://raw.githubusercontent.com/DIRACGrid/DIRAC/refs/tags/v9.0.16/LICENSE', template='https://raw.githubusercontent.com/DIRACGrid/DIRAC/refs/tags/v${{ version }}/LICENSE', context={'version': '9.0.16'}, sha256='bb2af8a15ea39a351e7a95d93cf8e4251c1ae6ae4cac8ee3a89cf9b155cd6e54', md5=None),
+  })
+# ---
 # name: test_variant_variables_source_render
   set({
     Source(url='https://pypi.org/packages/source/p/polars-lts-cpu/polars_lts_cpu-1.20.0.tar.gz', template="https://pypi.org/packages/source/p/${{ polars_variant }}/${{ polars_variant | replace('-', '_') }}-${{ version }}.tar.gz", context={'version': '1.20.0'}, sha256='f8770fe1a752f60828ec73e6215c7dadcb2badd1f34dcb1def7a0f4ca0ac36f8', md5=None),

--- a/tests/data/outputs_only_sources.yaml
+++ b/tests/data/outputs_only_sources.yaml
@@ -1,0 +1,25 @@
+context:
+  version: 9.0.16
+
+recipe:
+  name: dirac-grid
+  version: ${{ version }}
+
+outputs:
+  - package:
+      name: diraccommon
+      version: ${{ version }}
+
+    source:
+      - url: https://pypi.org/packages/source/d/diraccommon/diraccommon-${{ version }}.tar.gz
+        sha256: 7ae43c63075770e1314c40f2e7bd7708ae22a45262489e8912b881adf9f1aa2c
+      - url: https://raw.githubusercontent.com/DIRACGrid/DIRAC/refs/tags/v${{ version }}/LICENSE
+        sha256: bb2af8a15ea39a351e7a95d93cf8e4251c1ae6ae4cac8ee3a89cf9b155cd6e54
+
+  - package:
+      name: dirac-grid
+      version: ${{ version }}
+
+    source:
+      - url: https://pypi.org/packages/source/d/dirac/dirac-${{ version }}.tar.gz
+        sha256: 548b85b3b0ecf17487f3deba5073763583dd7eb812bf063f409153fc44c7402f

--- a/tests/test_recipe_sources.py
+++ b/tests/test_recipe_sources.py
@@ -53,6 +53,17 @@ def test_conditional_source_render(snapshot) -> None:
     assert sources == snapshot
 
 
+def test_outputs_only_source_render(snapshot) -> None:
+    outputs_only = test_data / "outputs_only_sources.yaml"
+
+    recipe_yaml = load_yaml(outputs_only.read_text())
+    variants: list[dict[str, list[str]]] = [{}]
+
+    sources = render_all_sources(recipe_yaml, variants)
+    assert len(sources) == 3
+    assert sources == snapshot
+
+
 def test_variant_variables_source_render(snapshot) -> None:
     polars = test_data / "polars" / "sources.yaml"
     variants = (test_data / "polars" / "ci_support").glob("*.yaml")


### PR DESCRIPTION
## Summary

- `render_all_sources` only checked `recipe.get("source")` at the top level, so multi-output recipes that define sources only per-output returned an empty set
- This caused the conda-forge version update bot to fail with *"no source sections were found in the rendered recipe"* (e.g. [conda-forge/dirac-grid-feedstock#179](https://github.com/conda-forge/dirac-grid-feedstock/pull/179))
- The sibling function `get_all_sources` in the same file already correctly handles all three source locations (top-level, `cache`, `outputs`); this aligns `render_all_sources` to do the same