### PR TITLE
fix: recipe parsing with empty variant

### DIFF
--- a/src/rattler_build_conda_compat/jinja/jinja.py
+++ b/src/rattler_build_conda_compat/jinja/jinja.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import contextlib
 from typing import Any, Mapping, TypedDict
 
 import jinja2
+from jinja2 import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 
 from rattler_build_conda_compat.jinja.filters import _bool, _split, _version_to_build_string
@@ -21,10 +23,16 @@ class RecipeWithContext(TypedDict, total=False):
     context: dict[str, str]
 
 
-def jinja_env(variant_config: Mapping[str, str] | None = None) -> SandboxedEnvironment:
+def jinja_env(variant_config: Mapping[str, str]) -> SandboxedEnvironment:
     """
     Create a `rattler-build` specific Jinja2 environment with modified syntax.
-    Target platform, build platform, and mpi are set to linux-64 by default.
+
+    `variant_config` must provide the variant variables that the recipe's
+    context section may reference (e.g. `target_platform`, `build_platform`,
+    plus any compiler/runtime keys used in expressions like
+    `${{ (foo | split('.'))[1] | int }}`). Without those, rendering recipe
+    contexts that perform operations on undefined values raises
+    `UndefinedError`, so callers must pass an explicit variant.
     """
 
     env = SandboxedEnvironment(
@@ -37,10 +45,6 @@ def jinja_env(variant_config: Mapping[str, str] | None = None) -> SandboxedEnvir
     )
 
     env_obj = _StubEnv()
-
-    # inject rattler-build recipe functions in jinja environment
-    if not variant_config:
-        variant_config = {"target_platform": "linux-64", "build_platform": "linux-64", "mpi": "mpi"}
 
     extra_vars = {}
     target_platform = variant_config.get("target_platform", "linux-64")
@@ -91,26 +95,93 @@ def jinja_env(variant_config: Mapping[str, str] | None = None) -> SandboxedEnvir
 def load_recipe_context(context: dict[str, str], jinja_env: jinja2.Environment) -> dict[str, str]:
     """
     Load all string values from the context dictionary as Jinja2 templates.
-    Use linux-64 as default target_platform, build_platform, and mpi.
+
+    Entries that fail with `UndefinedError` (e.g. variant-dependent
+    expressions like `${{ (foo | split('.'))[1] | int }}` when no variant
+    is provided) are left as their original template string, so callers
+    that only care about variant-independent entries can still proceed.
     """
-    # Process each key-value pair in the dictionary
     for key, value in context.items():
-        # If the value is a string, render it as a template
         if isinstance(value, str):
-            template = jinja_env.from_string(value)
-            rendered_value = template.render(context)
-            context[key] = rendered_value
+            with contextlib.suppress(UndefinedError):
+                context[key] = jinja_env.from_string(value).render(context)
 
     return context
 
 
+def _render_metadata_fields(
+    section: dict[str, Any],
+    fields: tuple[str, ...],
+    env: jinja2.Environment,
+    context: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a copy of `section` with named string fields rendered. Fields
+    whose templates fail with UndefinedError are left as-is."""
+    out = dict(section)
+    for field in fields:
+        value = out.get(field)
+        if not isinstance(value, str):
+            continue
+        with contextlib.suppress(UndefinedError):
+            out[field] = env.from_string(value).render(context)
+    return out
+
+
+def resolve_recipe_metadata(recipe_content: RecipeWithContext) -> dict[str, Any]:
+    """
+    Variant-free resolver for surface metadata (`name`, `version`, output
+    package names). Substitutes simple `${{ name }}`-style references
+    against the recipe's own `context:` section without rendering the
+    full body, so variant-dependent context entries (e.g.
+    `${{ (foo | split('.'))[1] | int }}`) don't crash the resolver.
+
+    Use this when you need to read the recipe's identity before a variant
+    matrix exists (e.g. for linting or pre-build metadata extraction).
+    For full rendering, use `render_recipe_with_context` with a real
+    `variant_config`.
+    """
+    env = jinja_env({})
+    context = load_recipe_context(dict(recipe_content.get("context", {})), env)
+
+    resolved: dict[str, Any] = dict(recipe_content)
+
+    for section_key in ("package", "recipe"):
+        section = resolved.get(section_key)
+        if isinstance(section, dict):
+            resolved[section_key] = _render_metadata_fields(section, ("name", "version"), env, context)
+
+    outputs = resolved.get("outputs")
+    if isinstance(outputs, list):
+        new_outputs = []
+        for output in outputs:
+            if not isinstance(output, dict):
+                new_outputs.append(output)
+                continue
+            new_output = _render_metadata_fields(output, ("name",), env, context)
+            pkg = new_output.get("package")
+            if isinstance(pkg, dict):
+                new_output["package"] = _render_metadata_fields(pkg, ("name", "version"), env, context)
+            new_outputs.append(new_output)
+        resolved["outputs"] = new_outputs
+
+    # Round-trip through YAML so callers receive ruamel CommentedMap/Seq
+    # types matching what `render_recipe_with_context` used to return.
+    return load_yaml(_dump_yaml_to_string(resolved))
+
+
 def render_recipe_with_context(
-    recipe_content: RecipeWithContext, variant_config: Mapping[str, str] | None = None
+    recipe_content: RecipeWithContext, variant_config: Mapping[str, str]
 ) -> dict[str, Any]:
     """
     Render the recipe using known values from context section.
     Unknown values are not evaluated and are kept as it is.
-    Target platform, build platform, and mpi are set to linux-64 by default.
+
+    `variant_config` is required: the recipe's `context:` may reference
+    variant variables (target_platform, compiler runtimes, etc.) and Jinja
+    expressions like `${{ (foo | split('.'))[1] | int }}` raise
+    `UndefinedError` if their inputs are missing. Callers without a real
+    variant matrix should not call this — extract `name`/`version`
+    structurally instead.
 
     Examples:
     ---
@@ -118,7 +189,10 @@ def render_recipe_with_context(
     >>> from pathlib import Path
     >>> from rattler_build_conda_compat.loader import load_yaml
     >>> recipe_content = load_yaml((Path().resolve() / "tests" / "data" / "eval_recipe_using_context.yaml").read_text())
-    >>> evaluated_context = render_recipe_with_context(recipe_content)
+    >>> evaluated_context = render_recipe_with_context(
+    ...     recipe_content,
+    ...     {"target_platform": "linux-64", "build_platform": "linux-64"},
+    ... )
     >>> assert "my_value-${{ not_present_value }}" == evaluated_context["build"]["string"]
     >>>
     ```

--- a/src/rattler_build_conda_compat/modify_recipe.py
+++ b/src/rattler_build_conda_compat/modify_recipe.py
@@ -145,8 +145,12 @@ def update_version(file: Path, new_version: str, hash_: Hash | None) -> str:
 
     data["context"]["version"] = new_version
 
-    # set up the jinja context
-    env = jinja_env()
+    # set up the jinja context. We don't have a real variant matrix here
+    # (this runs as part of a version bump, before any build), so pass an
+    # empty variant_config — `target_platform` etc. fall back to linux-64
+    # inside `jinja_env`, and any variant-dependent context entries are
+    # tolerated by `load_recipe_context`.
+    env = jinja_env({})
     context = copy.deepcopy(data.get("context", {}))
     context_variables = load_recipe_context(context, env)
     # for r-recipes we add the default `cran_mirror` variable

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -25,7 +25,7 @@ from conda_build.variants import (
 from conda_build.metadata import get_selectors, check_bad_chrs
 from conda_build.config import Config
 
-from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
+from rattler_build_conda_compat.jinja.jinja import resolve_recipe_metadata
 from rattler_build_conda_compat.loader import load_yaml, parse_recipe_config_file
 from rattler_build_conda_compat.utils import _get_recipe_metadata, find_recipe
 from rattler_build_conda_compat.yaml import _yaml_object
@@ -71,7 +71,12 @@ class MetaData(CondaMetaData):
 
         yaml_content = load_yaml(recipe_path.read_text(encoding="utf-8"))
 
-        return render_recipe_with_context(yaml_content)
+        # Variants are unknown at this point (rattler-build computes them
+        # during the actual render below), so we use the variant-free
+        # resolver. It only substitutes simple `${{ name }}`-style refs
+        # needed for `name()`/`version()`, and leaves any context entries
+        # that depend on variant variables untouched.
+        return resolve_recipe_metadata(yaml_content)
 
     def name(self) -> str:
         """

--- a/tests/__snapshots__/test_rattler_render.ambr
+++ b/tests/__snapshots__/test_rattler_render.ambr
@@ -13,8 +13,8 @@
       }),
       'requirements': CommentedMap({
         'build': CommentedSeq([
-          'c_compiler_stub',
-          'cuda_compiler_stub',
+          "${{ compiler('c') }}",
+          "${{ compiler('cuda') }}",
         ]),
         'host': CommentedSeq([
           'python',

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -11,11 +11,18 @@ from rattler_build_conda_compat.yaml import _dump_yaml_to_string
 test_data = Path(__file__).parent / "data"
 
 
+_DEFAULT_VARIANT = {
+    "target_platform": "linux-64",
+    "build_platform": "linux-64",
+    "mpi": "mpi",
+}
+
+
 def test_render_recipe_with_context(snapshot) -> None:
     recipe = Path("tests/data/mamba_recipe.yaml")
     recipe_yaml = load_yaml(recipe.read_text())
 
-    rendered = render_recipe_with_context(recipe_yaml)
+    rendered = render_recipe_with_context(recipe_yaml, _DEFAULT_VARIANT)
     into_yaml = _dump_yaml_to_string(rendered)
 
     assert into_yaml == snapshot
@@ -34,7 +41,7 @@ def test_context_rendering(snapshot) -> None:
 
     recipe_yaml = load_yaml(recipe.read_text())
 
-    rendered = render_recipe_with_context(recipe_yaml)
+    rendered = render_recipe_with_context(recipe_yaml, _DEFAULT_VARIANT)
     into_yaml = _dump_yaml_to_string(rendered)
 
     assert into_yaml == snapshot


### PR DESCRIPTION
@baszalmstra found an issue in `vc-feedstock` where the context contains some variables dependent on the variant. That failed the render ... 


Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
