### PR TITLE
fix: tolerate unrendered Jinja in package name during conda-smithy init

### DIFF
--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -8,6 +8,7 @@ import json
 from itertools import chain
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 import tempfile
@@ -65,6 +66,22 @@ def _staging_flattened_recipe_dir(recipe_dir: str, meta_name: str) -> Iterator[s
             os.symlink(entry, tmp_path / entry.name)
         (tmp_path / meta_name).write_text(flattened, encoding="utf-8")
         yield str(tmp_path)
+
+
+# Matches an unevaluated rattler-build Jinja expression, e.g. ``${{ go_variant_str }}``.
+_UNRENDERED_JINJA_EXPRESSION = re.compile(r"\$\{\{.*?\}\}")
+
+
+def _strip_unrendered_jinja(value: str) -> str:
+    """Remove unevaluated rattler-build Jinja expressions (``${{ ... }}``) from ``value``.
+
+    When a recipe has not been rendered, fields such as ``package/name`` may still
+    contain Jinja expressions if they depend on a build variant defined in
+    ``conda_build_config.yaml`` (e.g. ``go-${{ go_variant_str }}-compiler``). Those
+    expressions are not part of the literal value, so this strips them before the
+    value is validated for bad characters.
+    """
+    return _UNRENDERED_JINJA_EXPRESSION.sub("", value)
 
 
 class MetaData(CondaMetaData):
@@ -133,10 +150,17 @@ class MetaData(CondaMetaData):
         if not name:
             raise ValueError(f"Error: package/name missing in: {self.meta_path!r}")
 
-        if name != name.lower():
+        # When the recipe has not been rendered yet, the name may still contain
+        # unevaluated Jinja expressions if it depends on a build variant defined in
+        # conda_build_config.yaml (e.g. ``go-${{ go_variant_str }}-compiler``). Those
+        # expressions are not part of the package name, so validate only the literal
+        # portion that surrounds them.
+        name_to_check = name if self._rendered else _strip_unrendered_jinja(name)
+
+        if name_to_check != name_to_check.lower():
             raise ValueError(f"Error: package/name must be lowercase, got: {name!r}")
 
-        check_bad_chrs(name, "package/name")
+        check_bad_chrs(name_to_check, "package/name")
         return name
 
     def build_id(self) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,11 @@ def multiple_outputs() -> Path:
 
 
 @pytest.fixture
+def variant_name_recipe() -> Path:
+    return Path("tests/data/variant_name_recipe.yaml")
+
+
+@pytest.fixture
 def feedstock_dir_with_recipe(tmpdir: Path) -> Path:
     feedstock_dir = tmpdir / "feedstock"
 

--- a/tests/data/variant_name_recipe.yaml
+++ b/tests/data/variant_name_recipe.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/prefix-dev/recipe-format/main/schema.json
+
+context:
+  version: "1.26.4"
+
+package:
+  # The package name depends on the ``go_variant_str`` build variant, which is
+  # defined in conda_build_config.yaml and is therefore unknown until the recipe
+  # is rendered with variants.
+  name: go-${{ go_variant_str }}-compiler
+  version: ${{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - go-${{ go_variant_str }}_${{ target_platform }} ${{ version }}.*
+
+about:
+  homepage: https://go.dev/
+  license: BSD-3-Clause
+  summary: The Go compiler

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -98,6 +98,23 @@ def test_metadata_for_multiple_output(feedstock_dir_with_recipe: Path, mamba_rec
     assert rattler_metadata.version() == "1.5.8"
 
 
+def test_metadata_name_with_variant_in_name(
+    feedstock_dir_with_recipe: Path, variant_name_recipe: Path
+) -> None:
+    # The unrendered recipe name depends on a build variant (``go_variant_str``)
+    # defined in conda_build_config.yaml, so it still contains an unevaluated Jinja
+    # expression. ``name()`` (used e.g. by ``conda-smithy init``) must not treat the
+    # ``$`` from that expression as a bad character.
+    (feedstock_dir_with_recipe / "recipe" / "recipe.yaml").write_text(
+        variant_name_recipe.read_text(), encoding="utf8"
+    )
+
+    rattler_metadata = MetaData(feedstock_dir_with_recipe)
+
+    assert rattler_metadata.name() == "go-${{ go_variant_str }}-compiler"
+    assert rattler_metadata.version() == "1.26.4"
+
+
 def test_metadata_when_rendering_single_output(
     feedstock_dir_with_recipe: Path, rich_recipe: Path
 ) -> None:


### PR DESCRIPTION
I noticed that https://github.com/conda-forge/staged-recipes/pull/33708 was failing to convert due to:

```python
Making feedstock for go-compiler
Traceback (most recent call last):
  File "/home/runner/Miniforge3/bin/conda-smithy", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_smithy/cli.py", line 785, in main
    args.subcommand_func(args)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_smithy/cli.py", line 149, in __call__
    package=argparse.Namespace(name=meta.name())
                                    ~~~~~~~~~^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/rattler_build_conda_compat/render.py", line 139, in name
    check_bad_chrs(name, "package/name")
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/Miniforge3/lib/python3.13/site-packages/conda_build/metadata.py", line 834, in check_bad_chrs
    raise CondaBuildUserError(
        f"Bad character(s) ({''.join(sorted(invalid))}) in {field}: {value}."
    )
conda_build.exceptions.CondaBuildUserError: Bad character(s) ( $) in package/name: go-${{ go_variant_str }}-compiler.
```

I think this is a suitable fix unless we want to handle it another way.

cc @xhochy 