### PR TITLE
fix: tolerate variant-dependent context when parsing recipes

### DIFF
--- a/src/rattler_build_conda_compat/jinja/jinja.py
+++ b/src/rattler_build_conda_compat/jinja/jinja.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, TypedDict
 
 import jinja2
+from jinja2 import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from ruamel.yaml.scalarstring import DoubleQuotedScalarString, SingleQuotedScalarString
 
@@ -92,18 +93,35 @@ def jinja_env(variant_config: Mapping[str, str] | None = None) -> SandboxedEnvir
     return env
 
 
+def _try_render(env: jinja2.Environment, template: str, context: Mapping[str, Any]) -> str | None:
+    """
+    Render a template string against the given context. Returns None when the
+    template performs operations (filters, indexing, attribute access) on
+    variables that are not defined, e.g. variant variables that are only known
+    once a variant config exists.
+    """
+    try:
+        rendered = env.from_string(template).render(context)
+    except UndefinedError:
+        return None
+    return rendered
+
+
 def load_recipe_context(context: dict[str, str], jinja_env: jinja2.Environment) -> dict[str, str]:
     """
     Load all string values from the context dictionary as Jinja2 templates.
     Use linux-64 as default target_platform, build_platform, and mpi.
+    Entries that cannot be evaluated because they operate on undefined
+    variables (e.g. variant variables) keep their original template string.
     """
 
     # Process each key-value pair in the dictionary
     for key, value in context.items():
         # If the value is a string, render it as a template
         if isinstance(value, str):
-            template = jinja_env.from_string(value)
-            rendered_value = template.render(context)
+            rendered_value = _try_render(jinja_env, value, context)
+            if rendered_value is None:
+                continue
             # In this repo, rumael.yaml is configured to return strings as special subtypes
             # depending on how the user specified them in the yaml. Two of the subtypes,
             # SingleQuotedScalarString and DoubleQuotedScalarString, correspond to strings
@@ -131,6 +149,75 @@ def load_recipe_context(context: dict[str, str], jinja_env: jinja2.Environment) 
                 context[key] = _value
 
     return context
+
+
+def _render_resolvable_fields(
+    section: Mapping[str, Any],
+    fields: tuple[str, ...],
+    env: jinja2.Environment,
+    context: Mapping[str, Any],
+) -> dict[str, Any]:
+    """
+    Return a copy of `section` with the given string fields rendered against
+    `context`. Fields that cannot be fully resolved (their rendered value
+    still contains a template expression) keep their original value.
+    """
+    resolved = dict(section)
+    for field in fields:
+        value = resolved.get(field)
+        if not isinstance(value, str):
+            continue
+        rendered = _try_render(env, value, context)
+        if rendered is not None and "${{" not in rendered:
+            resolved[field] = rendered
+    return resolved
+
+
+def resolve_recipe_metadata(recipe_content: RecipeWithContext) -> dict[str, Any]:
+    """
+    Resolve the surface metadata of a recipe (package/recipe name and version,
+    output package names) against its context section, without rendering the
+    recipe body. Fields and context entries that depend on variant variables
+    (e.g. ``${{ (vcver | split(".")) [0] }}``) keep their template string, so
+    this works without a variant config.
+
+    To render the whole recipe, use `render_recipe_with_context` with a
+    variant config instead.
+    """
+    env = jinja_env()
+    context = load_recipe_context(dict(recipe_content.get("context", {})), env)
+
+    resolved: dict[str, Any] = dict(recipe_content)
+    if "context" in resolved:
+        resolved["context"] = context
+
+    for section_key in ("package", "recipe"):
+        section = resolved.get(section_key)
+        if isinstance(section, dict):
+            resolved[section_key] = _render_resolvable_fields(
+                section, ("name", "version"), env, context
+            )
+
+    outputs = resolved.get("outputs")
+    if isinstance(outputs, list):
+        resolved_outputs = []
+        for output in outputs:
+            if not isinstance(output, dict):
+                resolved_outputs.append(output)
+                continue
+            resolved_output = dict(output)
+            for section_key in ("package", "staging"):
+                section = resolved_output.get(section_key)
+                if isinstance(section, dict):
+                    resolved_output[section_key] = _render_resolvable_fields(
+                        section, ("name", "version"), env, context
+                    )
+            resolved_outputs.append(resolved_output)
+        resolved["outputs"] = resolved_outputs
+
+    # dump and reload so the result consists of the same ruamel.yaml types
+    # with the same scalar type inference as a fully rendered recipe
+    return load_yaml(_dump_yaml_to_string(resolved))  # type: ignore[no-any-return]
 
 
 def render_recipe_with_context(

--- a/src/rattler_build_conda_compat/render.py
+++ b/src/rattler_build_conda_compat/render.py
@@ -27,7 +27,7 @@ from conda_build.variants import (
 from conda_build.metadata import get_selectors, check_bad_chrs
 from conda_build.config import Config
 
-from rattler_build_conda_compat.jinja.jinja import render_recipe_with_context
+from rattler_build_conda_compat.jinja.jinja import resolve_recipe_metadata
 from rattler_build_conda_compat.loader import load_yaml, parse_recipe_config_file
 from rattler_build_conda_compat.outputs import flatten_staging_inheritance
 from rattler_build_conda_compat.utils import _get_recipe_metadata, find_recipe
@@ -114,7 +114,11 @@ class MetaData(CondaMetaData):
         raw_text = recipe_path.read_text(encoding="utf-8")
         yaml_content = load_yaml(flatten_staging_inheritance(raw_text))
 
-        return render_recipe_with_context(yaml_content)
+        # No variant matrix exists yet at this point (rattler-build computes
+        # it during render_recipes), so only the surface metadata is resolved
+        # here. Context entries that depend on variant variables stay as
+        # template strings.
+        return resolve_recipe_metadata(yaml_content)
 
     def name(self) -> str:
         """

--- a/tests/__snapshots__/test_rattler_render.ambr
+++ b/tests/__snapshots__/test_rattler_render.ambr
@@ -13,8 +13,8 @@
       }),
       'requirements': CommentedMap({
         'build': CommentedSeq([
-          'c_compiler_stub',
-          'cuda_compiler_stub',
+          "${{ compiler('c') }}",
+          "${{ compiler('cuda') }}",
         ]),
         'host': CommentedSeq([
           'python',

--- a/tests/data/variant_context.yaml
+++ b/tests/data/variant_context.yaml
@@ -1,0 +1,31 @@
+# Trimmed-down version of the conda-forge vc-feedstock v1 recipe. The context
+# section computes values from variant variables (vcver, cl_version,
+# runtime_version) that are only defined in the variant config at build time.
+schema_version: 1
+
+context:
+  runtime_year: "2015"
+  vc_major: ${{ (vcver | split(".")) [0] }}
+  vcvars_ver_maj: ${{ ((cl_version | split(".")) [0] | int) - 5 }}
+  vcvars_ver_min: ${{ (cl_version | split(".")) [1] | int }}
+  vcvars_ver: ${{ vcvars_ver_maj }}.${{ vcvars_ver_min }}
+  build_num: 34
+
+recipe:
+  name: vc-feedstock
+  version: ${{ runtime_version }}
+
+build:
+  number: ${{ build_num }}
+  skip: not win
+
+outputs:
+  - package:
+      name: vcomp${{ vc_major }}
+      version: ${{ runtime_version }}
+    build:
+      number: ${{ build_num }}
+
+  - package:
+      name: vs${{ runtime_year }}_runtime
+      version: ${{ runtime_version }}

--- a/tests/test_jinja.py
+++ b/tests/test_jinja.py
@@ -8,6 +8,7 @@ from rattler_build_conda_compat.jinja.jinja import (
     jinja_env,
     load_recipe_context,
     render_recipe_with_context,
+    resolve_recipe_metadata,
 )
 from rattler_build_conda_compat.jinja.utils import _MissingUndefined
 from rattler_build_conda_compat.loader import load_yaml
@@ -59,6 +60,44 @@ def test_context_rendering(snapshot) -> None:
     into_yaml = _dump_yaml_to_string(rendered)
 
     assert into_yaml == snapshot
+
+
+def test_load_recipe_context_keeps_variant_dependent_entries() -> None:
+    recipe_yaml = load_yaml((test_data / "variant_context.yaml").read_text())
+    context = recipe_yaml["context"]
+
+    loaded_context = load_recipe_context(context, jinja_env())
+
+    assert loaded_context["runtime_year"] == "2015"
+    assert loaded_context["build_num"] == 34
+    # entries that operate on variant variables cannot be evaluated without a
+    # variant config and keep their original template string
+    assert loaded_context["vc_major"] == '${{ (vcver | split(".")) [0] }}'
+    assert loaded_context["vcvars_ver_maj"] == '${{ ((cl_version | split(".")) [0] | int) - 5 }}'
+
+
+def test_resolve_recipe_metadata_with_variant_dependent_context() -> None:
+    recipe_yaml = load_yaml((test_data / "variant_context.yaml").read_text())
+
+    resolved = resolve_recipe_metadata(recipe_yaml)
+
+    assert resolved["recipe"]["name"] == "vc-feedstock"
+    # version depends on a variant variable and stays a template
+    assert resolved["recipe"]["version"] == "${{ runtime_version }}"
+    outputs = resolved["outputs"]
+    # vc_major is variant-dependent, so the name stays a template
+    assert outputs[0]["package"]["name"] == "vcomp${{ vc_major }}"
+    # runtime_year is a plain context value and resolves
+    assert outputs[1]["package"]["name"] == "vs2015_runtime"
+
+
+def test_resolve_recipe_metadata_single_output() -> None:
+    recipe_yaml = load_yaml((test_data / "context.yaml").read_text())
+
+    resolved = resolve_recipe_metadata(recipe_yaml)
+
+    assert resolved["package"]["name"] == "foo"
+    assert resolved["package"]["version"] == "bla"
 
 
 def test_load_recipe_context() -> None:

--- a/tests/test_rattler_render.py
+++ b/tests/test_rattler_render.py
@@ -75,6 +75,24 @@ def test_metadata_parse_recipe_flattens_staging(
     assert "source" in libfoo
 
 
+def test_metadata_with_variant_dependent_context(
+    feedstock_dir_with_recipe: Path, data_dir: Path
+) -> None:
+    """Recipes like vc-feedstock compute context values from variant variables
+    (e.g. ``${{ (vcver | split(".")) [0] }}``). Those are only known once the
+    variant matrix exists, so parsing the recipe must not require them.
+    """
+    (feedstock_dir_with_recipe / "recipe" / "recipe.yaml").write_text(
+        (data_dir / "variant_context.yaml").read_text(),
+        encoding="utf8",
+    )
+
+    meta = MetaData(feedstock_dir_with_recipe)
+
+    assert meta.name() == "vc-feedstock"
+    assert meta.meta["context"]["vc_major"] == '${{ (vcver | split(".")) [0] }}'
+
+
 def test_metadata_for_single_output(feedstock_dir_with_recipe: Path, rich_recipe: Path) -> None:
     (feedstock_dir_with_recipe / "recipe" / "recipe.yaml").write_text(
         rich_recipe.read_text(), encoding="utf8"


### PR DESCRIPTION
#128 was supposed to contain this change, but only the lock file update ended up on the PR branch. This is the actual fix, rebased onto current main.

Recipes like vc-feedstock compute `context:` values from variant variables, e.g. `${{ (vcver | split(".")) [0] }}`. Parsing such a recipe raised `UndefinedError` because no variant config exists at that point.

- `load_recipe_context` now keeps the original template string for entries that cannot be evaluated
- `MetaData.parse_recipe` only resolves **surface metadata** (name, version, output names) via the new `resolve_recipe_metadata` instead of rendering the whole recipe body

Fixes the problem encountered in https://github.com/conda-forge/vc-feedstock/pull/120#issuecomment-4337641200
